### PR TITLE
Add `get_$(varname)_path()` functions for all products

### DIFF
--- a/src/products/executable_generators.jl
+++ b/src/products/executable_generators.jl
@@ -14,7 +14,12 @@ function declare_old_executable_product(product_name)
                 adjust_LIBPATH,
             )
         end
+
+        # This will eventually be replaced with a `Ref{String}`
         $(path_name) = ""
+        function $(Symbol(string("get_", product_name, "_path")))()
+            return $(path_name)::String
+        end
     end
 end
 

--- a/src/products/file_generators.jl
+++ b/src/products/file_generators.jl
@@ -1,9 +1,13 @@
 macro declare_file_product(product_name)
+    get_path_name = Symbol(string("get_", product_name, "_path"))
     path_name = Symbol(string(product_name, "_path"))
     return esc(quote
-        # These will be filled in by init_file_product()
+        # These will be filled in by init_file_product().
         $(path_name) = ""
         $(product_name) = ""
+        function $(get_path_name)()
+            return $(path_name)::String
+        end
     end)
 end
 

--- a/src/products/library_generators.jl
+++ b/src/products/library_generators.jl
@@ -1,36 +1,43 @@
 
 function declare_old_library_product(product_name, product_soname)
-    handle_name = Symbol(string(product_name, "_handle"))
-    path_name = Symbol(string(product_name, "_path"))
     return esc(quote
-        # This will be filled in by init_library_product()
-        $(handle_name) = C_NULL
-        $(path_name) = ""
 
-        # On Julia 1.5-, this must be `const` and must be the SONAME
-        const $(product_name) = $(product_soname)
     end)
 end
 
 function declare_new_library_product(product_name)
     handle_name = Symbol(string(product_name, "_handle"))
+    get_path_name = Symbol(string("get_", product_name, "_path"))
     path_name = Symbol(string(product_name, "_path"))
-    return esc(quote
-        # These will be filled in by init_library_product()
-        $(handle_name) = C_NULL
-        $(path_name) = ""
-
-        # On Julia 1.6+, this doesn't have to be `const`!  Thanks Jeff!
-        $(product_name) = ""
-    end)
 end
 
 macro declare_library_product(product_name, product_soname)
+    handle_name = Symbol(string(product_name, "_handle"))
+    get_path_name = Symbol(string("get_", product_name, "_path"))
+    path_name = Symbol(string(product_name, "_path"))
     @static if VERSION < v"1.6.0-DEV"
-        return declare_old_library_product(product_name, product_soname)
+        lib_declaration = quote
+            # On Julia 1.5-, this must be `const` and must be the SONAME
+            const $(product_name) = $(product_soname)
+        end
     else
-        return declare_new_library_product(product_name)
+        lib_declaration = quote
+            # On Julia 1.6+, this doesn't have to be `const`!  Thanks Jeff!
+            $(product_name) = ""
+        end
     end
+    
+    return excat(
+        quote
+            # These will be filled in by init_library_product()
+            $(handle_name) = C_NULL
+            $(path_name) = ""
+            function $(get_path_name)()
+                return $(path_name)::String
+            end
+        end,
+        lib_declaration,
+    )
 end
 
 function init_new_library_product(product_name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,8 @@ module TestJLL end
         @test_nowarn @eval TestJLL using Vulkan_Headers_jll
         @test @eval TestJLL Vulkan_Headers_jll.is_available()
         @test isfile(@eval TestJLL vk_xml)
+        @test isfile(@eval TestJLL Vulkan_Headers_jll.vk_xml_path)
+        @test isfile(@eval TestJLL Vulkan_Headers_jll.get_vk_xml_path())
         @test isdir(@eval TestJLL Vulkan_Headers_jll.artifact_dir)
         # Package with an ExecutableProduct
         Pkg.develop(PackageSpec(path=joinpath(@__DIR__, "HelloWorldC_jll")))
@@ -21,6 +23,8 @@ module TestJLL end
         else
             @test @eval TestJLL HelloWorldC_jll.is_available()
             @test "Hello, World!" == @eval TestJLL hello_world(h->readchomp(`$h`))
+            @test isfile(@eval TestJLL HelloWorldC_jll.hello_world_path)
+            @test isfile(@eval TestJLL HelloWorldC_jll.get_hello_world_path())
             @test isdir(@eval TestJLL HelloWorldC_jll.artifact_dir)
         end
         # Package with a LibraryProduct
@@ -28,6 +32,8 @@ module TestJLL end
         @test_nowarn @eval TestJLL using OpenLibm_jll
         @test @eval TestJLL OpenLibm_jll.is_available()
         @test exp(3.14) ≈ @eval TestJLL ccall((:exp, libopenlibm), Cdouble, (Cdouble,), 3.14)
+        @test isfile(@eval TestJLL OpenLibm_jll.libopenlibm_path)
+        @test isfile(@eval TestJLL OpenLibm_jll.get_libopenlibm_path())
         @test isdir(@eval TestJLL OpenLibm_jll.artifact_dir)
     end
 end


### PR DESCRIPTION
This gives packages a better API for accessing the path of an executable