### PR TITLE
Revert `Ref` around the path variable

### DIFF
--- a/src/products/executable_generators.jl
+++ b/src/products/executable_generators.jl
@@ -7,7 +7,7 @@ function declare_old_executable_product(product_name)
             return Base.invokelatest(
                 JLLWrappers.withenv_executable_wrapper,
                 f,
-                $(Symbol("$(product_name)_path"))[],
+                $(Symbol("$(product_name)_path")),
                 PATH[],
                 LIBPATH[],
                 adjust_PATH,
@@ -15,9 +15,10 @@ function declare_old_executable_product(product_name)
             )
         end
 
-        $(path_name) = Ref{String}()
+        # This will eventually be replaced with a `Ref{String}`
+        $(path_name) = ""
         function $(Symbol(string("get_", product_name, "_path")))()
-            return $(path_name)[]
+            return $(path_name)::String
         end
     end
 end
@@ -38,7 +39,7 @@ function declare_new_executable_product(product_name)
                     adjust_PATH,
                     adjust_LIBPATH,
                 )
-                return Cmd(Cmd([$(path_name)[]]); env)
+                return Cmd(Cmd([$(path_name)]); env)
             end
 
             # Signal to concerned parties that they should use the new version, eventually.
@@ -60,7 +61,7 @@ macro init_executable_product(product_name, product_path)
     path_name = Symbol(string(product_name, "_path"))
     return esc(quote
         # Locate the executable on-disk, store into $(path_name)
-        $(path_name)[] = joinpath(artifact_dir, $(product_path))
+        global $(path_name) = joinpath(artifact_dir, $(product_path))
 
         # Add this executable's directory onto the list of PATH's that we'll need to expose to dependents
         push!(PATH_list, joinpath(artifact_dir, $(dirname(product_path))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ module TestJLL end
         else
             @test @eval TestJLL HelloWorldC_jll.is_available()
             @test "Hello, World!" == @eval TestJLL hello_world(h->readchomp(`$h`))
-            @test isfile(@eval TestJLL HelloWorldC_jll.hello_world_path[])
+            @test isfile(@eval TestJLL HelloWorldC_jll.hello_world_path)
             @test isfile(@eval TestJLL HelloWorldC_jll.get_hello_world_path())
             @test isdir(@eval TestJLL HelloWorldC_jll.artifact_dir)
             @test !isempty(@eval TestJLL HelloWorldC_jll.PATH[])


### PR DESCRIPTION
Partially revert #12.  While ideally that's the right thing to do, I'm a bit nervous that some packages might be using this variable, which would actually be wrong because they should use the wrapper.  In https://github.com/JuliaPackaging/JLLWrappers.jl/pull/12#issuecomment-696330296 I pointed to a `lib*_path`, which however is for a library, not an executable.  I'm not aware of anyone using the `_path` variable for executables into the wild.