### PR TITLE
run JLLWrappers without inference

### DIFF
--- a/src/JLLWrappers.jl
+++ b/src/JLLWrappers.jl
@@ -1,5 +1,9 @@
 module JLLWrappers
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@compiler_options"))
+    @eval Base.Experimental.@compiler_options compile=min optimize=0 infer=false
+end
+
 # We need to glue expressions together a lot
 function excat(exs::Union{Expr,Nothing}...)
     ex = Expr(:block)


### PR DESCRIPTION
The code generation part in JLLWrappers has to be compiled every time a package is compiled.
Since the packages are quite small, this takes a non negligble amount of time.

Takes of ~2 seconds from precompiling GTK_jll

Perhaps this should be isolated to the parts that run during precompilation though?