### PR TITLE
Fix Windows double-adjustment of `PATH`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JLLWrappers"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 authors = ["Mosè Giordano", "Elliot Saba"]
-version = "1.1.1"
+version = "1.1.2"
 
 [compat]
 julia = "1.0.0"

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -85,6 +85,10 @@ Return the library paths that e.g. libjulia and such are stored in.
 function get_julia_libpaths()
     if isempty(JULIA_LIBDIRS)
         append!(JULIA_LIBDIRS, [joinpath(Sys.BINDIR, Base.LIBDIR, "julia"), joinpath(Sys.BINDIR, Base.LIBDIR)])
+        # Windows needs to see the BINDIR as well
+        @static if Sys.iswindows()
+            push!(JULIA_LIBDIRS, Sys.BINDIR)
+        end
     end
     return JULIA_LIBDIRS
 end

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -14,19 +14,21 @@ else
 end
 
 function adjust_ENV!(env::Dict, PATH::String, LIBPATH::String, adjust_PATH::Bool, adjust_LIBPATH::Bool)
-    if adjust_PATH
-        if !isempty(get(env, "PATH", ""))
-            env["PATH"] = string(PATH, pathsep, env["PATH"])
-        else
-            env["PATH"] = PATH
-        end
-    end
     if adjust_LIBPATH
         LIBPATH_base = get(env, LIBPATH_env, expanduser(LIBPATH_default))
         if !isempty(LIBPATH_base)
             env[LIBPATH_env] = string(LIBPATH, pathsep, LIBPATH_base)
         else
             env[LIBPATH_env] = LIBPATH
+        end
+    end
+    if adjust_PATH && (LIBPATH_env != "PATH" || !adjust_LIBPATH)
+        if adjust_PATH
+            if !isempty(get(env, "PATH", ""))
+                env["PATH"] = string(PATH, pathsep, env["PATH"])
+            else
+                env["PATH"] = PATH
+            end
         end
     end
     return env

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ module TestJLL end
 
         # Issue #20
         if Sys.iswindows()
-            @test occursin(Sys.BINDIR, JLLWrappers.get_julia_libpaths())
+            @test Sys.BINDIR ∈ JLLWrappers.get_julia_libpaths()
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,5 +41,10 @@ module TestJLL end
         @test isdir(@eval TestJLL OpenLibm_jll.artifact_dir)
         @test isempty(@eval TestJLL OpenLibm_jll.PATH[])
         @test occursin(Sys.BINDIR, @eval TestJLL OpenLibm_jll.LIBPATH[])
+
+        # Issue #20
+        if Sys.iswindows()
+            @test occursin(Sys.BINDIR, JLLWrappers.get_julia_libpaths())
+        end
     end
 end


### PR DESCRIPTION
On windows, `LIBPATH_env` == `"PATH"`, and we don't want to
double-adjust `PATH`.