### PR TITLE
linux: don't add system library dir to LIBDIRS

### DIFF
--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -84,7 +84,11 @@ Return the library paths that e.g. libjulia and such are stored in.
 """
 function get_julia_libpaths()
     if isempty(JULIA_LIBDIRS)
-        append!(JULIA_LIBDIRS, [joinpath(Sys.BINDIR, Base.LIBDIR, "julia"), joinpath(Sys.BINDIR, Base.LIBDIR)])
+        push!(JULIA_LIBDIRS, joinpath(Sys.BINDIR, Base.LIBDIR, "julia"))
+        @static if !Sys.islinux() || Sys.BINDIR != "/usr/bin"
+            # avoid adding /usr/lib to LD_LIBRARY_PATH on linux
+            push!(JULIA_LIBDIRS, joinpath(Sys.BINDIR, Base.LIBDIR))
+        end
         # Windows needs to see the BINDIR as well
         @static if Sys.iswindows()
             push!(JULIA_LIBDIRS, Sys.BINDIR)


### PR DESCRIPTION
Adding `/usr/lib` or similar paths to `LD_LIBRARY_PATH` can cause many weird errors and is not needed.
Checking for `BINDIR != /usr/bin` should also cover variants like `/usr/lib64` or `/usr/lib/$arch`.

Note: I do know that this kind of setup is not recommended or supported by julia but it does exist in many distributions and I think this is a reasonable adaption for such use-cases.