### PR TITLE
Generate wrapper header: override override path

### DIFF
--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -2,13 +2,14 @@ include("products/executable_generators.jl")
 include("products/file_generators.jl")
 include("products/library_generators.jl")
 
-macro generate_wrapper_header(src_name)
+macro generate_wrapper_header(src_name, override_path = nothing)
     pkg_dir = dirname(dirname(String(__source__.file)))
+    override = something(override_path,joinpath(dirname(pkg_dir), "override"))
     return esc(quote
         function find_artifact_dir()
             # We determine at compile-time whether our JLL package has been dev'ed and overridden
-            @static if isdir(joinpath(dirname($(pkg_dir)), "override"))
-                return joinpath(dirname($(pkg_dir)), "override")
+            @static if isdir($override)
+                return $override
             else
                 # We explicitly use `macrocall` here so that we can manually pass the `__source__`
                 # argument, to avoid `@artifact_str` trying to lookup `Artifacts.toml` here.


### PR DESCRIPTION
Make @generate_wrapper_header take an optional parameter with the overridden path.

This can be used to system packagers to specify a custom binary path manually instead of having to rely on "override"  (by replacing generate_wrapper_header("package") with generate_wrapper_header("package", binary_path)