### PR TITLE
Do not make JLL packages require `Preferences`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - "1.3"
           - "1.4"
           - "1.5"
+          - "^1.6.0-0"
           - "nightly"
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,16 @@ uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 authors = ["Mosè Giordano", "Elliot Saba"]
 version = "1.3.0"
 
+[deps]
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+
 [compat]
+Preferences = "1.2.1"
 julia = "1.0.0"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [targets]
-test = ["Pkg", "Test", "Preferences"]
+test = ["Pkg", "Test"]

--- a/src/JLLWrappers.jl
+++ b/src/JLLWrappers.jl
@@ -4,6 +4,10 @@ if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@compi
     @eval Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 end
 
+if VERSION >= v"1.6.0-DEV"
+    using Preferences
+end
+
 # We need to glue expressions together a lot
 function excat(exs::Union{Expr,Nothing}...)
     ex = Expr(:block)

--- a/src/toplevel_generators.jl
+++ b/src/toplevel_generators.jl
@@ -35,7 +35,7 @@ function generate_imports(src_name)
     else
         # Use fast stdlib-based Artifacts + Preferences
         return quote
-            using Libdl, Artifacts, Preferences, Base.BinaryPlatforms
+            using Libdl, Artifacts, JLLWrappers.Preferences, Base.BinaryPlatforms
             using Artifacts: load_artifacts_toml, unpack_platform
             using Base.BinaryPlatforms: triplet, select_platform
         end

--- a/test/HelloWorldC_jll/Project.toml
+++ b/test/HelloWorldC_jll/Project.toml
@@ -7,7 +7,6 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 julia = "1.0"

--- a/test/OpenLibm_jll/Project.toml
+++ b/test/OpenLibm_jll/Project.toml
@@ -7,7 +7,6 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 julia = "1.0"

--- a/test/Vulkan_Headers_jll/Project.toml
+++ b/test/Vulkan_Headers_jll/Project.toml
@@ -7,7 +7,6 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 julia = "1.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using JLLWrappers
 using Pkg
 using Test
 
+# We use preferences only in Julia v1.6+
 @static if VERSION >= v"1.6.0-DEV"
     using Preferences
 end


### PR DESCRIPTION
This will make the introduction of `Preferences` non-breaking: as it is now,
packages need to have `Preferences` in their own environment.