### PR TITLE
Add docstrings for `ExecutableProduct` wrappers

### DIFF
--- a/src/products/executable_generators.jl
+++ b/src/products/executable_generators.jl
@@ -14,7 +14,7 @@ function declare_old_executable_product(product_name)
         end
         ```
 
-        !!! compat "Julia 1.0"
+        !!! compat "Julia 1.3"
         """
         function $(product_name)(f::Function; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
             # We sub off to a shared function to avoid compiling the same thing over and over again

--- a/src/products/executable_generators.jl
+++ b/src/products/executable_generators.jl
@@ -2,6 +2,20 @@ function declare_old_executable_product(product_name)
     path_name = Symbol(string(product_name, "_path"))
     return quote
         # This is the old-style `withenv()`-based function
+        """
+            $($product_name)(f::Function; adjust_PATH::Bool=true, adjust_LIBPATH::Bool=true)
+
+        An `ExecutableProduct` wrapper that supports the execution of $($product_name).
+
+        # Example
+        ```julia
+        $($product_name)() do exe
+            run(`\$exe \$arguments`)
+        end
+        ```
+
+        !!! compat "Julia 1.0"
+        """
         function $(product_name)(f::Function; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
             # We sub off to a shared function to avoid compiling the same thing over and over again
             return Base.invokelatest(
@@ -30,6 +44,19 @@ function declare_new_executable_product(product_name)
         path_name = Symbol(string(product_name, "_path"))
         return quote
             # This is the new-style `addenv()`-based function
+            @doc """
+                $($product_name)(; adjust_PATH::Bool=true, adjust_LIBPATH::Bool=true) -> Cmd
+
+            An `ExecutableProduct` wrapper that supports the execution of $($product_name).
+            This wrapper is thread-safe and should be preferred on Julia 1.6+.
+
+            # Example
+            ```julia
+            run(`\$($($product_name)()) \$arguments`)
+            ```
+
+            !!! compat "Julia 1.6"
+            """
             function $(product_name)(; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
                 env = Base.invokelatest(
                     JLLWrappers.adjust_ENV!,


### PR DESCRIPTION
I tend to use these wrappers little enough that I forget what the current state-of-the-art is. My first thought is to check the docstrings for these wrappers so this will help refresh my memory without having to recall the location of the fully documentation (https://docs.binarybuilder.org/stable/jll/#ExecutableProduct)