### PR TITLE
Fix `libopenblas64_.so` not found on archlinux

### DIFF
--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -9,7 +9,7 @@ elseif Sys.isapple()
     const pathsep = ':'
 else
     const LIBPATH_env = "LD_LIBRARY_PATH"
-    const LIBPATH_default = ""
+    const LIBPATH_default = "/usr/lib:/usr/lib/julia"
     const pathsep = ':'
 end
 


### PR DESCRIPTION
This should fix the infamous error message on archlinux, see https://github.com/JuliaLinearAlgebra/Arpack.jl/issues/97
```
ERROR: LoadError: InitError: could not load library "~/.julia/artifacts/cdf6dc8aa6771a61c6c65a5a5c1a8d1b75f50a2f/lib/libarpack.so"
libopenblas64_.so: cannot open shared object file: No such file or directory
```
The cause of the problem is that, on archlinux,  some libs for julia are placed at `/usr/lib/julia`, which is not in `LD_LIBRARY_PATH`. 

It can also be solved by adding the following line to `~/.julia/config/startup.jl`. (I only tested this way on my machine)
```
ENV["LD_LIBRARY_PATH"]="/usr/lib:/usr/lib/julia"
```