### PR TITLE
Fix a `@debug` statement that fails if `host_platform` is `nothing`

### DIFF
--- a/src/toplevel_generators.jl
+++ b/src/toplevel_generators.jl
@@ -182,7 +182,7 @@ function generate_wrapper_load(src_name, pkg_uuid, __source__)
 
         # Load in the wrapper, if it's not `nothing`!
         if best_wrapper === nothing
-            @debug(string("Unable to load ", $(src_name), "; unsupported platform ", host_platform === nothing ? nothing : triplet(host_platform)))
+            @debug(string("Unable to load ", $(src_name), "; unsupported platform ", host_platform === nothing ? triplet(HostPlatform()) : triplet(host_platform)))
             is_available() = false
         else
             Base.include($(Symbol("$(src_name)_jll")), best_wrapper)

--- a/src/toplevel_generators.jl
+++ b/src/toplevel_generators.jl
@@ -182,7 +182,7 @@ function generate_wrapper_load(src_name, pkg_uuid, __source__)
 
         # Load in the wrapper, if it's not `nothing`!
         if best_wrapper === nothing
-            @debug(string("Unable to load ", $(src_name), "; unsupported platform ", triplet(host_platform)))
+            @debug(string("Unable to load ", $(src_name), "; unsupported platform ", host_platform === nothing ? nothing : triplet(host_platform)))
             is_available() = false
         else
             Base.include($(Symbol("$(src_name)_jll")), best_wrapper)


### PR DESCRIPTION
If `host_plaform` is nothing, then `triplet(host_platform)` will throw `MethodError: no method matching triplet(::Nothing)`, and thus the `@debug` statement will fail to be printed. Therefore, if `host_platform` is `nothing`, we should not try to call `triplet(host_platform)` in the `@debug` statement.