### PR TITLE
enable typed globals on 1.9 prereleases

### DIFF
--- a/src/JLLWrappers.jl
+++ b/src/JLLWrappers.jl
@@ -8,7 +8,7 @@ if VERSION >= v"1.6.0-DEV"
     using Preferences
 end
 
-const global_typeassert_available = VERSION >= v"1.9.0"
+const global_typeassert_available = VERSION >= v"1.9.0-"
 
 # We need to glue expressions together a lot
 function excat(exs::Union{Expr,Nothing}...)


### PR DESCRIPTION
Not sure if it is worth forcing recompilation of all jlls for this but I want to have this locally at least for some testing.