### PR TITLE
precompile find_artifact_dir

### DIFF
--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -17,6 +17,9 @@ macro generate_wrapper_header(src_name)
                 return $(Expr(:macrocall, Symbol("@artifact_str"), __source__, src_name))
             end
         end
+        if ccall(:jl_generating_output, Cint, ()) == 1
+            find_artifact_dir() # to precompile this into Pkgimage
+        end
     end)
 end
 


### PR DESCRIPTION
Seems to be beneficial

Before
```
julia> @time_imports using LLVMExtra_jll
      0.4 ms  LazyArtifacts
     10.7 ms  Preferences
      1.0 ms  JLLWrappers
               ┌ 35.1 ms LLVMExtra_jll.__init__() 11.12% compilation time
     82.6 ms  LLVMExtra_jll 59.69% compilation time
```

This PR
```
julia> @time_imports using LLVMExtra_jll
      0.5 ms  LazyArtifacts
     10.9 ms  Preferences
      0.7 ms  JLLWrappers
               ┌ 6.5 ms LLVMExtra_jll.__init__() 55.44% compilation time
     50.0 ms  LLVMExtra_jll 90.38% compilation time
```