### PR TITLE
Define new `at-generate_jll_init` macro to replace hardcoded `__init__`

### DIFF
--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -52,6 +52,13 @@ macro generate_init_footer()
     end)
 end
 
+macro generate_jll_init(expr::Expr)
+    return quote
+        function $(esc(Symbol("__init__")))()
+            $(esc(expr))
+        end # __init__()
+    end
+end
 
 """
     emit_preference_path_load(pref_name, default_value)

--- a/test/HelloWorldC_jll/src/wrappers/aarch64-linux-gnu.jl
+++ b/test/HelloWorldC_jll/src/wrappers/aarch64-linux-gnu.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/aarch64-linux-musl.jl
+++ b/test/HelloWorldC_jll/src/wrappers/aarch64-linux-musl.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/armv7l-linux-gnueabihf.jl
+++ b/test/HelloWorldC_jll/src/wrappers/armv7l-linux-gnueabihf.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/armv7l-linux-musleabihf.jl
+++ b/test/HelloWorldC_jll/src/wrappers/armv7l-linux-musleabihf.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/i686-linux-gnu.jl
+++ b/test/HelloWorldC_jll/src/wrappers/i686-linux-gnu.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/i686-linux-musl.jl
+++ b/test/HelloWorldC_jll/src/wrappers/i686-linux-musl.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/i686-w64-mingw32.jl
+++ b/test/HelloWorldC_jll/src/wrappers/i686-w64-mingw32.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/powerpc64le-linux-gnu.jl
+++ b/test/HelloWorldC_jll/src/wrappers/powerpc64le-linux-gnu.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/x86_64-apple-darwin14.jl
+++ b/test/HelloWorldC_jll/src/wrappers/x86_64-apple-darwin14.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/x86_64-linux-gnu.jl
+++ b/test/HelloWorldC_jll/src/wrappers/x86_64-linux-gnu.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/x86_64-linux-musl.jl
+++ b/test/HelloWorldC_jll/src/wrappers/x86_64-linux-musl.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/HelloWorldC_jll/src/wrappers/x86_64-w64-mingw32.jl
+++ b/test/HelloWorldC_jll/src/wrappers/x86_64-w64-mingw32.jl
@@ -4,7 +4,7 @@ export hello_world, goodbye_world
 JLLWrappers.@generate_wrapper_header("HelloWorldC")
 JLLWrappers.@declare_executable_product(hello_world)
 JLLWrappers.@declare_executable_product(goodbye_world)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_executable_product(
         hello_world,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran4-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran4-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran4-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran4-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran4-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran4-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran4-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran4-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran5-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran5-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran5-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran5-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran5-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran5-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran5-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/aarch64-linux-gnu-libgfortran5-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran4-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran4-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran4-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran4-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran4-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran4-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran4-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran4-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran5-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran5-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran5-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran5-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran5-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran5-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran5-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/armv7l-linux-gnueabihf-libgfortran5-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran4-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran4-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran4-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran4-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran4-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran4-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran4-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran4-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran5-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran5-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran5-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran5-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran5-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran5-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran5-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-linux-gnu-libgfortran5-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-w64-mingw32-libgfortran4-cxx03-mpi+microsoftmpi.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-w64-mingw32-libgfortran4-cxx03-mpi+microsoftmpi.jl
@@ -7,7 +7,7 @@ using MicrosoftMPI_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.dll")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MicrosoftMPI_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-w64-mingw32-libgfortran4-cxx11-mpi+microsoftmpi.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-w64-mingw32-libgfortran4-cxx11-mpi+microsoftmpi.jl
@@ -7,7 +7,7 @@ using MicrosoftMPI_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.dll")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MicrosoftMPI_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-w64-mingw32-libgfortran5-cxx03-mpi+microsoftmpi.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-w64-mingw32-libgfortran5-cxx03-mpi+microsoftmpi.jl
@@ -7,7 +7,7 @@ using MicrosoftMPI_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.dll")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MicrosoftMPI_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/i686-w64-mingw32-libgfortran5-cxx11-mpi+microsoftmpi.jl
+++ b/test/LAMMPS_jll/src/wrappers/i686-w64-mingw32-libgfortran5-cxx11-mpi+microsoftmpi.jl
@@ -7,7 +7,7 @@ using MicrosoftMPI_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.dll")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MicrosoftMPI_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran4-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran4-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran4-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran4-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran4-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran4-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran4-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran4-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran5-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran5-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran5-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran5-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran5-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran5-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran5-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/powerpc64le-linux-gnu-libgfortran5-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-apple-darwin-libgfortran4-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-apple-darwin-libgfortran4-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "@rpath/liblammps.0.dylib")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-apple-darwin-libgfortran4-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-apple-darwin-libgfortran4-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "@rpath/liblammps.0.dylib")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-apple-darwin-libgfortran5-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-apple-darwin-libgfortran5-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "@rpath/liblammps.0.dylib")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-apple-darwin-libgfortran5-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-apple-darwin-libgfortran5-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "@rpath/liblammps.0.dylib")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran4-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran4-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran4-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran4-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran4-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran4-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran4-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran4-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran5-cxx03-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran5-cxx03-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran5-cxx03-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran5-cxx03-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran5-cxx11-mpi+mpich.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran5-cxx11-mpi+mpich.jl
@@ -7,7 +7,7 @@ using MPICH_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPICH_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran5-cxx11-mpi+mpitrampoline.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-linux-gnu-libgfortran5-cxx11-mpi+mpitrampoline.jl
@@ -7,7 +7,7 @@ using MPItrampoline_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.so.0")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MPItrampoline_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-w64-mingw32-libgfortran4-cxx03-mpi+microsoftmpi.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-w64-mingw32-libgfortran4-cxx03-mpi+microsoftmpi.jl
@@ -7,7 +7,7 @@ using MicrosoftMPI_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.dll")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MicrosoftMPI_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-w64-mingw32-libgfortran4-cxx11-mpi+microsoftmpi.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-w64-mingw32-libgfortran4-cxx11-mpi+microsoftmpi.jl
@@ -7,7 +7,7 @@ using MicrosoftMPI_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.dll")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MicrosoftMPI_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-w64-mingw32-libgfortran5-cxx03-mpi+microsoftmpi.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-w64-mingw32-libgfortran5-cxx03-mpi+microsoftmpi.jl
@@ -7,7 +7,7 @@ using MicrosoftMPI_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.dll")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MicrosoftMPI_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/LAMMPS_jll/src/wrappers/x86_64-w64-mingw32-libgfortran5-cxx11-mpi+microsoftmpi.jl
+++ b/test/LAMMPS_jll/src/wrappers/x86_64-w64-mingw32-libgfortran5-cxx11-mpi+microsoftmpi.jl
@@ -7,7 +7,7 @@ using MicrosoftMPI_jll
 JLLWrappers.@generate_wrapper_header("LAMMPS")
 JLLWrappers.@declare_library_product(liblammps, "liblammps.dll")
 JLLWrappers.@declare_executable_product(lmp)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header(CompilerSupportLibraries_jll, Preferences, MicrosoftMPI_jll)
     JLLWrappers.@init_library_product(
         liblammps,
@@ -21,4 +21,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/aarch64-linux-gnu.jl
+++ b/test/OpenLibm_jll/src/wrappers/aarch64-linux-gnu.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/aarch64-linux-musl.jl
+++ b/test/OpenLibm_jll/src/wrappers/aarch64-linux-musl.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/armv7l-linux-gnueabihf.jl
+++ b/test/OpenLibm_jll/src/wrappers/armv7l-linux-gnueabihf.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/armv7l-linux-musleabihf.jl
+++ b/test/OpenLibm_jll/src/wrappers/armv7l-linux-musleabihf.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/i686-linux-gnu.jl
+++ b/test/OpenLibm_jll/src/wrappers/i686-linux-gnu.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/i686-linux-musl.jl
+++ b/test/OpenLibm_jll/src/wrappers/i686-linux-musl.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/i686-w64-mingw32.jl
+++ b/test/OpenLibm_jll/src/wrappers/i686-w64-mingw32.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.dll")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.dll")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/powerpc64le-linux-gnu.jl
+++ b/test/OpenLibm_jll/src/wrappers/powerpc64le-linux-gnu.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/x86_64-apple-darwin.jl
+++ b/test/OpenLibm_jll/src/wrappers/x86_64-apple-darwin.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "@rpath/libopenlibm.3.dylib")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.0.dylib")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/x86_64-linux-gnu.jl
+++ b/test/OpenLibm_jll/src/wrappers/x86_64-linux-gnu.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/x86_64-linux-musl.jl
+++ b/test/OpenLibm_jll/src/wrappers/x86_64-linux-musl.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/x86_64-unknown-freebsd11.1.jl
+++ b/test/OpenLibm_jll/src/wrappers/x86_64-unknown-freebsd11.1.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.so.3")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.so.0")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/OpenLibm_jll/src/wrappers/x86_64-w64-mingw32.jl
+++ b/test/OpenLibm_jll/src/wrappers/x86_64-w64-mingw32.jl
@@ -4,7 +4,7 @@ export libopenlibm
 JLLWrappers.@generate_wrapper_header("OpenLibm")
 JLLWrappers.@declare_library_product(libopenlibm, "libopenlibm.dll")
 JLLWrappers.@declare_library_product(libnonexisting, "libnonexisting.dll")
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_library_product(
         libopenlibm,
@@ -18,4 +18,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end

--- a/test/Vulkan_Headers_jll/src/wrappers/any.jl
+++ b/test/Vulkan_Headers_jll/src/wrappers/any.jl
@@ -4,7 +4,7 @@ export vk_xml, vulkan_hpp
 JLLWrappers.@generate_wrapper_header("Vulkan_Headers")
 JLLWrappers.@declare_file_product(vulkan_hpp)
 JLLWrappers.@declare_file_product(vk_xml)
-function __init__()
+JLLWrappers.@generate_jll_init begin
     JLLWrappers.@generate_init_header()
     JLLWrappers.@init_file_product(
         vulkan_hpp,
@@ -16,4 +16,4 @@ function __init__()
     )
 
     JLLWrappers.@generate_init_footer()
-end  # __init__()
+end


### PR DESCRIPTION
In case in the future we will have a different mechanism than `__init__`.  This also makes #54 easier, the wrapper footer could be included directly into this macro.