### PR TITLE
Actually deprecate non-`do`-block form of executable products

### DIFF
--- a/src/products/executable_generators.jl
+++ b/src/products/executable_generators.jl
@@ -17,6 +17,7 @@ function declare_old_executable_product(product_name)
         !!! compat "Julia 1.3"
         """
         function $(product_name)(f::Function; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
+            Base.depwarn(string($(product_name), "() is deprecated, use the non-do-block form"), $(string(product_name)))
             # We sub off to a shared function to avoid compiling the same thing over and over again
             return Base.invokelatest(
                 JLLWrappers.withenv_executable_wrapper,
@@ -72,9 +73,6 @@ function declare_new_executable_product(product_name)
                 )
                 return Cmd(Cmd([$(path_name)]); env)
             end
-
-            # Signal to concerned parties that they should use the new version, eventually.
-            #@deprecate $(product_name)(func) $(product_name)()
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,7 +82,9 @@ module TestJLL end
                 @test output == "Hello, World!"
             else
                 output = @eval TestJLL begin
-                    readchomp(`$(hello_world())`)
+                    hello_world() do exe
+                        readchomp(`$(exe)`)
+                    end
                 end
                 @test output == "Hello, World!"
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,29 @@ module TestJLL end
             else
                 @test basename(@eval TestJLL HelloWorldC_jll.get_goodbye_world_path()) == "goodbye_world"
             end
+
+            @static if VERSION >= v"1.6.0"
+                # Test old-style exe execution
+                @test_logs (:warn, "hello_world() is deprecated, use the non-do-block form") begin
+                    output = @eval TestJLL begin
+                        hello_world() do exe
+                            readchomp(`$(exe)`)
+                        end
+                    end
+                end
+                @test output == "Hello, World!"
+
+                # Test new-style exe execution
+                output = @eval TestJLL begin
+                    readchomp(`$(hello_world())`)
+                end
+                @test output == "Hello, World!"
+            else
+                output = @eval TestJLL begin
+                    readchomp(`$(hello_world())`)
+                end
+                @test output == "Hello, World!"
+            end
         end
 
         # Package with a LibraryProduct


### PR DESCRIPTION
By the time Julia v1.11 lands, I'd like to have removed this from `JLLWrappers` completely.  This older form is not thread-safe, and so should be strongly discouraged.