### PR TITLE
Add `eager_mode()` definition and call in `__init__()`

### DIFF
--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -20,24 +20,30 @@ macro generate_wrapper_header(src_name)
         if ccall(:jl_generating_output, Cint, ()) == 1
             Base.precompile(find_artifact_dir, ()) # to precompile this into Pkgimage
         end
+        eager_mode() = nothing
     end)
 end
 
 
 macro generate_init_header(dependencies...)
     deps_path_add = Expr[]
+    eager_mode = Expr[]
     if !isempty(dependencies)
         for dep in dependencies
             push!(deps_path_add, quote
                 isdefined($(dep), :PATH_list) && append!(PATH_list, $(dep).PATH_list)
                 isdefined($(dep), :LIBPATH_list) && append!(LIBPATH_list, $(dep).LIBPATH_list)
             end)
+            push!(eager_mode, :(isdefined($(dep), :eager_mode) && $(dep).eager_mode()))
         end
     end
 
     return excat(
         # This either calls `@artifact_str()`, or returns a constant string if we're overridden.
         :(global artifact_dir = find_artifact_dir()),
+
+        # Add `eager_mode` invocations on all our dependencies
+        eager_mode...,
 
         # Initialize PATH_list and LIBPATH_list
         deps_path_add...,


### PR DESCRIPTION
New work on BB2 will create a `LazyJLLWrappers` that has a (slightly) different API, and is lazily-loaded.  In order to be compatible with JLLs that still use `JLLWrappers`, we define an `eager_mode()` method that eagerly loads all libraries for use in a downstream JLL that still uses `JLLWrappers`.

This PR adds no-op `eager_mode()` implementations for all old JLLs, and invokes `eager_mode()` on all dependencies to pave the way for this interopability.