### PR TITLE
Avoid side effects when precompiling `find_artifact_dir`

### DIFF
--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -18,7 +18,7 @@ macro generate_wrapper_header(src_name)
             end
         end
         if ccall(:jl_generating_output, Cint, ()) == 1
-            find_artifact_dir() # to precompile this into Pkgimage
+            Base.precompile(find_artifact_dir, ()) # to precompile this into Pkgimage
         end
     end)
 end


### PR DESCRIPTION
With an explicit call to `find_artifact_dir()` we were actually fetching lazy artifacts during precompilation, which is typically undesired, besides hitting a bug in Downloads.jl in certain versions of Julia (up to 1.10.4) which causes the download of the artifact to hang.  Instead, with `Base.precompile` we retain the caching of native code, without causing extra downloads during precompilation.

Some benchmarks, same as in #53.  Before this PR:
```
julia> @time_imports using LLVMExtra_jll
      0.2 ms  LazyArtifacts
     13.6 ms  Preferences
      0.4 ms  JLLWrappers
               ┌ 6.8 ms LLVMExtra_jll.__init__() 59.45% compilation time
     50.7 ms  LLVMExtra_jll 92.31% compilation time
```
With this PR:
```
julia> @time_imports using LLVMExtra_jll
      0.2 ms  LazyArtifacts
     14.2 ms  Preferences
      0.5 ms  JLLWrappers
               ┌ 6.7 ms LLVMExtra_jll.__init__() 59.63% compilation time
     50.4 ms  LLVMExtra_jll 92.59% compilation time
```
So there's no penalty in using `Base.precompile`.  If I remove the forced precompilation entirely:
```
julia> @time_imports using LLVMExtra_jll
      0.2 ms  LazyArtifacts
     10.2 ms  Preferences
      0.4 ms  JLLWrappers
               ┌ 4.5 ms LLVMExtra_jll.__init__() 58.45% compilation time
     52.4 ms  LLVMExtra_jll 94.76% compilation time
```
This is slower than with the precompilation call, but not as bad as in #53.

Also, with this PR:
```
(@v1.10) pkg> add IntelOpenMP_jll
   Resolving package versions...
   Installed IntelOpenMP_jll ─ v2024.2.1+0
    Updating `~/.julia/environments/v1.10/Project.toml`
  [1d5cc7b8] + IntelOpenMP_jll v2024.2.1+0
    Updating `~/.julia/environments/v1.10/Manifest.toml`
  [1d5cc7b8] + IntelOpenMP_jll v2024.2.1+0
Precompiling project...
  1 dependency successfully precompiled in 1 seconds. 56 already precompiled.

julia> using IntelOpenMP_jll
  Downloaded artifact: IntelOpenMP

julia>
```
Download happens at `using`-time, not during precompilation, as intended.  Note that I'm using Julia 1.10.4, which would also cause the precompilation to last at least 30 seconds because of the Downloads.jl bug.

Fix #65.