### PR TITLE
[CI] Minor improvements to GHA setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           - "1.5"
           - "1.6"
           - "1.7"
+          - "1.8"
+          - "1.9"
           - "1"
           - "nightly"
         os:
@@ -28,27 +30,20 @@ jobs:
         julia-arch:
           - x64
           - x86
-        # 32-bit Julia binaries are not available on macOS
         exclude:
+          # 32-bit Julia binaries are not available on macOS
           - os: macOS-latest
             julia-arch: x86
+          # There seems to be an issue with Julia v1.4 on macOS:
+          # https://github.com/JuliaPackaging/JLLWrappers.jl/pull/67#issuecomment-2321873551
+          - os: macOS-latest
+            julia-version: 1.4
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-      - name: Cache artifacts
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
* Exclude Julia v1.4 on macOS, there's an issue with Julia itself on that
  platform
* Install dependabot
* Run CI on more Julia versions
* Use `julia-actions/cache` instead of `actions/cache`