### PR TITLE
Fix type instabilities in the init_header 

### DIFF
--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -34,13 +34,16 @@ macro generate_init_header(dependencies...)
                 isdefined($(dep), :PATH_list) && append!(PATH_list, $(dep).PATH_list)
                 isdefined($(dep), :LIBPATH_list) && append!(LIBPATH_list, $(dep).LIBPATH_list)
             end)
-            push!(eager_mode, :(isdefined($(dep), :eager_mode) && $(dep).eager_mode()))
+            depmod = getglobal(__module__, dep)
+            if isdefined(depmod, :eager_mode)
+                push!(eager_mode, :($(dep).eager_mode()))
+            end
         end
     end
 
     return excat(
         # This either calls `@artifact_str()`, or returns a constant string if we're overridden.
-        :(global artifact_dir = find_artifact_dir()),
+        :(global artifact_dir = find_artifact_dir()::String),
 
         # Add `eager_mode` invocations on all our dependencies
         eager_mode...,

--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -10,7 +10,7 @@ macro generate_wrapper_header(src_name)
             @static if isdir(joinpath(dirname($(pkg_dir)), "override"))
                 return joinpath(dirname($(pkg_dir)), "override")
             elseif @isdefined(augment_platform!) && VERSION >= v"1.6"
-                $(Expr(:macrocall, Symbol("@artifact_str"), __source__, src_name, :(host_platform)))
+                $(Expr(:macrocall, Symbol("@artifact_str"), __source__, src_name, __module__.host_platform))
             else
                 # We explicitly use `macrocall` here so that we can manually pass the `__source__`
                 # argument, to avoid `@artifact_str` trying to lookup `Artifacts.toml` here.

--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -30,11 +30,13 @@ macro generate_init_header(dependencies...)
     eager_mode = Expr[]
     if !isempty(dependencies)
         for dep in dependencies
-            push!(deps_path_add, quote
-                isdefined($(dep), :PATH_list) && append!(PATH_list, $(dep).PATH_list)
-                isdefined($(dep), :LIBPATH_list) && append!(LIBPATH_list, $(dep).LIBPATH_list)
-            end)
-            depmod = getglobal(__module__, dep)
+            depmod = getfield(__module__, dep)
+            if isdefined(depmod, :PATH_list)
+                push!(deps_path_add, :(append!(PATH_list, $(dep).PATH_list)))
+            end
+            if isdefined(depmod, :LIBPATH_list)
+                push!(deps_path_add, :(append!(LIBPATH_list, $(dep).LIBPATH_list)))
+            end
             if isdefined(depmod, :eager_mode)
                 push!(eager_mode, :($(dep).eager_mode()))
             end


### PR DESCRIPTION
find_artifact_dir is porrly inferred due to us disabling inference. Also eager_mode isn't defined in stdlib jlls so make that a macro time check instead of a runtime one. 