### PR TITLE
Use `tryparse` to parse platform triplet

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JLLWrappers"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 authors = ["Mosè Giordano", "Elliot Saba"]
-version = "1.6.1"
+version = "1.7.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ if VERSION <= v"1.6.0-DEV"
     ]
 else
     test_pkgs = [
-        ("HelloWorldC", v"1.3.0+0"),
+        ("HelloWorldC", v"1.4.0+0"),
         ("LAMMPS", v"2.4.0+0"),
         ("libxls", v"1.6.2+0"),
         ("Vulkan_Headers", v"1.3.243+1"),


### PR DESCRIPTION
This makes parsing more robust against unknown platforms, e.g. for architectures introduced in later versions of Julia than the currently running one.

This is needed to be able to publish JLL packages with RISC-V builds, also in versions of Julia older than v1.12.