### PR TITLE
precompile the eager_mode noop

### DIFF
--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -17,10 +17,12 @@ macro generate_wrapper_header(src_name)
                 return $(Expr(:macrocall, Symbol("@artifact_str"), __source__, src_name))
             end
         end
-        if ccall(:jl_generating_output, Cint, ()) == 1
-            Base.precompile(find_artifact_dir, ()) # to precompile this into Pkgimage
-        end
         eager_mode() = nothing
+        if ccall(:jl_generating_output, Cint, ()) == 1
+            # to precompile these into Pkgimage
+            Base.precompile(find_artifact_dir, ())
+            Base.precompile(eager_mode, ())
+        end
     end)
 end
 


### PR DESCRIPTION
These trip up loading. They're not expensive to compile, just makes sense to not have to dip into the compiler.

i.e. 

from https://github.com/JuliaLang/julia/pull/58436

```
julia> @trace_compile @time_imports using Plots
#=    4.6 ms =# precompile(Tuple{typeof(Base.vect), Array{String, 1}, Vararg{Array{String, 1}}})
#=    3.3 ms =# precompile(Tuple{typeof(Base.iterate), Array{Array{String, 1}, 1}})
      1.4 ms  Statistics
               ┌ 93.5 ms SuiteSparse_jll.__init__()
     94.6 ms  SuiteSparse_jll
      1.6 ms  Serialization
               ┌ 1.2 ms SparseArrays.CHOLMOD.__init__()
    123.1 ms  SparseArrays
      1.8 ms  #=    7.5 ms =# precompile(Tuple{typeof(Base.Filesystem.joinpath), NTuple{7, String}})
Statistics → SparseArraysExt
      1.5 ms  Preferences
      1.0 ms  PrecompileTools
      1.0 ms  Reexport
      1.3 ms  Scratch
      1.4 ms  RelocatableFolders
      3.8 ms  RecipesBase
     14.9 ms  FixedPointNumbers
               ┌ 0.0 ms ColorTypes.__init__()
     15.7 ms  ColorTypes
     24.3 ms  Colors
      2.2 ms  TensorCore
               ┌ 0.0 ms ColorVectorSpace.__init__()
     22.0 ms  ColorVectorSpace
      4.4 ms  ColorSchemes
      1.7 ms  StableRNGs
     39.1 ms  PlotUtils
      5.2 ms  PlotThemes
               ┌ 2.9 ms OpenLibm_jll.__init__()
      4.3 ms  OpenLibm_jll
      1.4 ms  NaNMath
     10.7 ms  RecipesPipeline
               ┌ 0.0 ms Requires.__init__()
      1.6 ms  Requires
      2.0 ms  UnicodeFun
      1.2 ms  ColorTypes → StyledStringsExt
      1.6 ms  DataAPI
      1.3 ms  Compat
      1.2 ms  Compat → CompatLinearAlgebraExt
      4.7 ms  OrderedCollections
     26.2 ms  DataStructures
      1.7 ms  SortingAlgorithms
      4.1 ms  Missings
               ┌ 0.0 ms DocStringExtensions.__init__()
      1.9 ms  DocStringExtensions
      6.5 ms  IrrationalConstants
      1.6 ms  LogExpFunctions
      1.6 ms  StatsAPI
      1.5 ms  PtrArrays
      2.2 ms  AliasTables
     10.2 ms  StatsBase
      1.5 ms  Showoff
      3.1 ms  Unzip
      1.5 ms  JLLWrappers
#=    0.0 ms =# precompile(Tuple{typeof(JLLWrappers.get_julia_libpaths)})
               ┌ 0.1 ms fzf_jll.__init__()
      1.5 ms  fzf_jll
      1.4 ms  JLFzf
      1.8 ms  Mmap
     11.9 ms  Parsers
      3.5 ms  JSON
      3.5 ms  Measures
               ┌ 2.2 ms Bzip2_jll.__init__()
      3.8 ms  Bzip2_jll
#=    0.0 ms =# precompile(Tuple{typeof(Bzip2_jll.eager_mode)})
               ┌ 2.2 ms FreeType2_jll.__init__()
      3.9 ms  FreeType2_jll
               ┌ 2.1 ms FriBidi_jll.__init__()
      3.7 ms  FriBidi_jll
               ┌ 4.1 ms Libiconv_jll.__init__()
      5.8 ms  Libiconv_jll
               ┌ 2.1 ms Libffi_jll.__init__()
      3.8 ms  Libffi_jll
#=    0.0 ms =# precompile(Tuple{typeof(Libiconv_jll.eager_mode)})
               ┌ 2.9 ms XML2_jll.__init__()
      4.7 ms  XML2_jll
#=    0.0 ms =# precompile(Tuple{typeof(XML2_jll.eager_mode)})
               ┌ 3.4 ms Gettext_jll.__init__()
      5.2 ms  Gettext_jll
               ┌ 4.4 ms PCRE2_jll.__init__()
      6.1 ms  PCRE2_jll
#=    0.0 ms =# precompile(Tuple{typeof(Libffi_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(Gettext_jll.eager_mode)})
               ┌ 12.5 ms Glib_jll.__init__()
     14.3 ms  Glib_jll
               ┌ 3.8 ms LLVMOpenMP_jll.__init__()
      5.7 ms  LLVMOpenMP_jll
#=    0.0 ms =# precompile(Tuple{typeof(LLVMOpenMP_jll.eager_mode)})
               ┌ 2.8 ms Pixman_jll.__init__()
      4.7 ms  Pixman_jll
               ┌ 2.5 ms libpng_jll.__init__()
      4.3 ms  libpng_jll
      1.8 ms  Libuuid_jll
               ┌ 2.4 ms Expat_jll.__init__()
      4.4 ms  Expat_jll
#=    0.0 ms =# precompile(Tuple{typeof(FreeType2_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(Expat_jll.eager_mode)})
               ┌ 2.4 ms Fontconfig_jll.__init__()
      4.5 ms  Fontconfig_jll
#=    0.0 ms =# precompile(Tuple{typeof(Glib_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(Pixman_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(libpng_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(Fontconfig_jll.eager_mode)})
               ┌ 7.5 ms Cairo_jll.__init__()
      9.5 ms  Cairo_jll
               ┌ 2.7 ms Graphite2_jll.__init__()
      4.7 ms  Graphite2_jll
#=    0.0 ms =# precompile(Tuple{typeof(Cairo_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(Graphite2_jll.eager_mode)})
               ┌ 7.8 ms HarfBuzz_jll.__init__()
      9.9 ms  HarfBuzz_jll
#=    0.0 ms =# precompile(Tuple{typeof(FriBidi_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(HarfBuzz_jll.eager_mode)})
               ┌ 2.9 ms libass_jll.__init__()
      5.0 ms  libass_jll
               ┌ 2.7 ms libfdk_aac_jll.__init__()
      4.8 ms  libfdk_aac_jll
               ┌ 2.9 ms LAME_jll.__init__()
      4.9 ms  LAME_jll
               ┌ 2.2 ms Ogg_jll.__init__()
      4.4 ms  Ogg_jll
#=    0.0 ms =# precompile(Tuple{typeof(Ogg_jll.eager_mode)})
               ┌ 8.0 ms libvorbis_jll.__init__()
     10.3 ms  libvorbis_jll
               ┌ 3.0 ms libaom_jll.__init__()
      5.3 ms  libaom_jll
               ┌ 2.9 ms x264_jll.__init__()
      5.1 ms  x264_jll
               ┌ 3.7 ms x265_jll.__init__()
      5.9 ms  x265_jll
               ┌ 2.9 ms Opus_jll.__init__()
      5.3 ms  Opus_jll
#=    0.0 ms =# precompile(Tuple{typeof(libass_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(libfdk_aac_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(LAME_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(libvorbis_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(libaom_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(x264_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(x265_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(Opus_jll.eager_mode)})
               ┌ 17.1 ms FFMPEG_jll.__init__()
     19.8 ms  FFMPEG_jll
      2.3 ms  FFMPEG
               ┌ 3.0 ms GLFW_jll.__init__()
      5.5 ms  GLFW_jll
               ┌ 6.2 ms JpegTurbo_jll.__init__()
      8.9 ms  JpegTurbo_jll
               ┌ 3.2 ms LERC_jll.__init__()
      5.8 ms  LERC_jll
               ┌ 2.9 ms XZ_jll.__init__()
      5.6 ms  XZ_jll
               ┌ 3.1 ms Zstd_jll.__init__()
      5.6 ms  Zstd_jll
#=    0.0 ms =# precompile(Tuple{typeof(JpegTurbo_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(LERC_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(XZ_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(Zstd_jll.eager_mode)})
               ┌ 3.2 ms Libtiff_jll.__init__()
      5.7 ms  Libtiff_jll
      2.5 ms  libinput_jll
      2.5 ms  Xorg_libXext_jll
      2.7 ms  Xorg_libxcb_jll
      2.5 ms  Xorg_xcb_util_wm_jll
      2.5 ms  Xorg_xcb_util_cursor_jll
      2.6 ms  Xorg_xcb_util_image_jll
      4.2 ms  Xorg_xcb_util_keysyms_jll
      2.7 ms  Xorg_xcb_util_renderutil_jll
      2.6 ms  Xorg_libXrender_jll
      2.7 ms  Xorg_libSM_jll
      2.6 ms  xkbcommon_jll
      2.7 ms  Libglvnd_jll
               ┌ 3.6 ms Vulkan_Loader_jll.__init__()
      6.4 ms  Vulkan_Loader_jll
#=    0.0 ms =# precompile(Tuple{typeof(Vulkan_Loader_jll.eager_mode)})
               ┌ 58.1 ms Qt6Base_jll.__init__()
     61.1 ms  Qt6Base_jll
#=    0.0 ms =# precompile(Tuple{typeof(FFMPEG_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(GLFW_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(Libtiff_jll.eager_mode)})
#=    0.0 ms =# precompile(Tuple{typeof(Qt6Base_jll.eager_mode)})
               ┌ 0.1 ms GR_jll.__init__()
      3.4 ms  GR_jll
               ┌ 0.1 ms GR.GRPreferences.__init__()
      9.3 ms  GR
               ┌ 0.5 ms Plots.__init__()
    339.5 ms  Plots
```

With this (and https://github.com/JuliaLang/julia/pull/58444)
```
julia> @time @time_imports using Plots
      0.8 ms  Printf
     12.7 ms  Dates
      0.8 ms  Statistics
               ┌ 0.0 ms SuiteSparse_jll.__init__()
      0.7 ms  SuiteSparse_jll
      1.0 ms  Serialization
    108.2 ms  SparseArrays
      0.6 ms  Statistics → SparseArraysExt
      0.9 ms  TOML
      0.8 ms  Preferences
      0.5 ms  PrecompileTools
      0.5 ms  Reexport
      0.6 ms  Scratch
      0.7 ms  RelocatableFolders
      2.4 ms  RecipesBase
     10.8 ms  FixedPointNumbers
               ┌ 0.0 ms ColorTypes.__init__()
     10.5 ms  ColorTypes
     20.5 ms  Colors
      0.8 ms  TensorCore
               ┌ 0.0 ms ColorVectorSpace.__init__()
     16.3 ms  ColorVectorSpace
      2.5 ms  ColorSchemes
      1.1 ms  StableRNGs
     55.8 ms  PlotUtils
      4.2 ms  PlotThemes
               ┌ 0.0 ms OpenLibm_jll.__init__()
      0.8 ms  OpenLibm_jll
      0.8 ms  NaNMath
      8.0 ms  RecipesPipeline
      0.7 ms  UUIDs
               ┌ 0.0 ms Requires.__init__()
      1.0 ms  Requires
      1.3 ms  UnicodeFun
      0.9 ms  ColorTypes → StyledStringsExt
      1.1 ms  DataAPI
      0.8 ms  Compat
      0.8 ms  Compat → CompatLinearAlgebraExt
      3.4 ms  OrderedCollections
     19.1 ms  DataStructures
      1.1 ms  SortingAlgorithms
      3.2 ms  Missings
               ┌ 0.0 ms DocStringExtensions.__init__()
      1.3 ms  DocStringExtensions
      5.2 ms  IrrationalConstants
      1.0 ms  LogExpFunctions
      0.9 ms  StatsAPI
      1.0 ms  PtrArrays
      1.4 ms  AliasTables
      7.3 ms  StatsBase
               ┌ 0.0 ms NetworkOptions.__init__()
      1.2 ms  NetworkOptions
      6.1 ms  ArgTools
               ┌ 0.0 ms nghttp2_jll.__init__()
      1.0 ms  nghttp2_jll
               ┌ 0.0 ms OpenSSL_jll.__init__()
      1.1 ms  OpenSSL_jll
               ┌ 0.0 ms LibSSH2_jll.__init__()
      1.0 ms  LibSSH2_jll
               ┌ 0.0 ms Zlib_jll.__init__()
      0.9 ms  Zlib_jll
               ┌ 0.0 ms LibCURL_jll.__init__()
      1.1 ms  LibCURL_jll
               ┌ 0.0 ms MozillaCACerts_jll.__init__()
      1.1 ms  MozillaCACerts_jll
               ┌ 0.0 ms LibCURL.__init__()
      2.0 ms  LibCURL
               ┌ 7.7 ms Downloads.Curl.__init__()
     13.1 ms  Downloads
      1.1 ms  Showoff
      2.5 ms  Unzip
      1.2 ms  JLLWrappers
               ┌ 0.1 ms fzf_jll.__init__()
      1.2 ms  fzf_jll
      1.0 ms  JLFzf
      1.2 ms  Mmap
      9.0 ms  Parsers
      2.8 ms  JSON
      2.7 ms  Measures
               ┌ 1.2 ms Bzip2_jll.__init__()
      2.4 ms  Bzip2_jll
               ┌ 10.7 ms FreeType2_jll.__init__() 87.01% compilation time
     11.9 ms  FreeType2_jll 77.81% compilation time
               ┌ 1.3 ms FriBidi_jll.__init__()
      2.7 ms  FriBidi_jll
               ┌ 2.5 ms Libiconv_jll.__init__()
      3.7 ms  Libiconv_jll
               ┌ 1.4 ms Libffi_jll.__init__()
      2.9 ms  Libffi_jll
               ┌ 1.4 ms XML2_jll.__init__()
      2.7 ms  XML2_jll
               ┌ 14.6 ms Gettext_jll.__init__()
     16.0 ms  Gettext_jll
               ┌ 0.0 ms PCRE2_jll.__init__()
      1.4 ms  PCRE2_jll
               ┌ 9.5 ms Glib_jll.__init__() 21.65% compilation time
     11.1 ms  Glib_jll 18.63% compilation time
               ┌ 1.8 ms LLVMOpenMP_jll.__init__()
      3.3 ms  LLVMOpenMP_jll
               ┌ 1.4 ms Pixman_jll.__init__()
      3.1 ms  Pixman_jll
               ┌ 1.5 ms libpng_jll.__init__()
      3.0 ms  libpng_jll
      1.5 ms  Libuuid_jll
               ┌ 1.6 ms Expat_jll.__init__()
      3.2 ms  Expat_jll
               ┌ 1.8 ms Fontconfig_jll.__init__()
      3.6 ms  Fontconfig_jll
               ┌ 5.1 ms Cairo_jll.__init__()
      6.8 ms  Cairo_jll
               ┌ 1.6 ms Graphite2_jll.__init__()
      3.3 ms  Graphite2_jll
               ┌ 5.4 ms HarfBuzz_jll.__init__()
      7.1 ms  HarfBuzz_jll
               ┌ 1.8 ms libass_jll.__init__()
      3.9 ms  libass_jll
               ┌ 1.7 ms libfdk_aac_jll.__init__()
      3.7 ms  libfdk_aac_jll
               ┌ 1.9 ms LAME_jll.__init__()
      3.9 ms  LAME_jll
               ┌ 4.2 ms Ogg_jll.__init__()
      6.0 ms  Ogg_jll
               ┌ 5.3 ms libvorbis_jll.__init__()
      7.2 ms  libvorbis_jll
               ┌ 2.0 ms libaom_jll.__init__()
      3.9 ms  libaom_jll
               ┌ 1.9 ms x264_jll.__init__()
      3.9 ms  x264_jll
               ┌ 2.0 ms x265_jll.__init__()
      4.1 ms  x265_jll
               ┌ 1.8 ms Opus_jll.__init__()
      3.9 ms  Opus_jll
               ┌ 13.7 ms FFMPEG_jll.__init__() 16.67% compilation time
     15.8 ms  FFMPEG_jll 14.46% compilation time
      2.1 ms  FFMPEG
               ┌ 2.6 ms GLFW_jll.__init__()
      4.8 ms  GLFW_jll
               ┌ 4.1 ms JpegTurbo_jll.__init__()
      6.5 ms  JpegTurbo_jll
               ┌ 2.2 ms LERC_jll.__init__()
      4.5 ms  LERC_jll
               ┌ 2.2 ms XZ_jll.__init__()
      4.4 ms  XZ_jll
               ┌ 2.2 ms Zstd_jll.__init__()
      4.6 ms  Zstd_jll
               ┌ 2.3 ms Libtiff_jll.__init__()
      4.6 ms  Libtiff_jll
      2.3 ms  libinput_jll
      2.2 ms  Xorg_libXext_jll
      2.1 ms  Xorg_libxcb_jll
      2.4 ms  Xorg_xcb_util_wm_jll
      2.3 ms  Xorg_xcb_util_cursor_jll
      2.2 ms  Xorg_xcb_util_image_jll
      2.3 ms  Xorg_xcb_util_keysyms_jll
      2.3 ms  Xorg_xcb_util_renderutil_jll
      2.2 ms  Xorg_libXrender_jll
      2.3 ms  Xorg_libSM_jll
      2.3 ms  xkbcommon_jll
      2.3 ms  Libglvnd_jll
               ┌ 2.5 ms Vulkan_Loader_jll.__init__()
      5.0 ms  Vulkan_Loader_jll
               ┌ 35.6 ms Qt6Base_jll.__init__()
     38.2 ms  Qt6Base_jll
               ┌ 0.1 ms GR_jll.__init__()
      2.9 ms  GR_jll
      3.4 ms  Tar
               ┌ 0.0 ms p7zip_jll.__init__()
      2.8 ms  p7zip_jll
               ┌ 0.1 ms GR.GRPreferences.__init__()
      7.5 ms  GR
               ┌ 0.2 ms Plots.__init__()
    230.2 ms  Plots
```