### PR TITLE
Don't skip adding to LIBPATH for dont_dlopen

### DIFF
--- a/src/products/library_generators.jl
+++ b/src/products/library_generators.jl
@@ -61,8 +61,8 @@ macro init_library_product(product_name, product_path, dlopen_flags)
             # dlopen_flags === nothing means to not dlopen the library.
             if $(dlopen_flags) !== nothing
                 global $(handle_name) = dlopen($(path_name)::String, $(dlopen_flags))
-                push!(LIBPATH_list, dirname($(path_name)::String))
             end
+            push!(LIBPATH_list, dirname($(path_name)::String))
         end,
         init_new_library_product(product_name, path_name),
     )


### PR DESCRIPTION
As discovered in https://github.com/JuliaPackaging/Yggdrasil/pull/12165, the executable functions for products don't work if any of their dependencies have dont_dlopen set. I don't think there's a strong reason to exclude these from LIBPATH, so change that.