### PR TITLE
Add precompilation instructions for lazy artifacts.

### DIFF
--- a/src/JLLWrappers.jl
+++ b/src/JLLWrappers.jl
@@ -2,6 +2,7 @@ module JLLWrappers
 
 @static if VERSION >= v"1.6.0-DEV"
     using Preferences
+    using Artifacts: Artifacts
 end
 
 @static if VERSION >= v"1.6.0-DEV"

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -92,3 +92,27 @@ function get_julia_libpaths()
     end
     return JULIA_LIBDIRS
 end
+
+# Precompile-time hook invoked by `@generate_wrapper_header` to cover the call sites
+# `find_artifact_dir` and `@generate_init_footer` reach at `__init__`
+@static if VERSION >= v"1.6.0-DEV"
+    function precompile_init_callsites(jll_module::Module)
+        # `@artifact_str` passes `Val(LA)` where `LA` is the first of these
+        # modules imported by the JLL.  The `Val{Artifacts}` flavour is already
+        # covered by a `precompile(...)` statement in the Artifacts stdlib itself.
+        for modname in (:LazyArtifacts, :Pkg, :PkgArtifacts)
+            if isdefined(jll_module, modname)
+                LA = getfield(jll_module, modname)
+                argtypes = (Module, String, SubString{String}, String, Dict{String,Any},
+                            Base.SHA1, Base.BinaryPlatforms.Platform, Val{LA})
+                Base.precompile(Artifacts._artifact_str, argtypes)
+                Base.precompile(Artifacts.__artifact_str, argtypes)
+                break
+            end
+        end
+        Base.precompile(get_julia_libpaths, ())
+        return nothing
+    end
+else
+    precompile_init_callsites(::Module) = nothing
+end

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -97,17 +97,23 @@ end
 # `find_artifact_dir` and `@generate_init_footer` reach at `__init__`
 @static if VERSION >= v"1.6.0-DEV"
     function precompile_init_callsites(jll_module::Module)
-        # `@artifact_str` passes `Val(LA)` where `LA` is the first of these
-        # modules imported by the JLL.  The `Val{Artifacts}` flavour is already
-        # covered by a `precompile(...)` statement in the Artifacts stdlib itself.
-        for modname in (:LazyArtifacts, :Pkg, :PkgArtifacts)
-            if isdefined(jll_module, modname)
-                LA = getfield(jll_module, modname)
-                argtypes = (Module, String, SubString{String}, String, Dict{String,Any},
-                            Base.SHA1, Base.BinaryPlatforms.Platform, Val{LA})
-                Base.precompile(Artifacts._artifact_str, argtypes)
-                Base.precompile(Artifacts.__artifact_str, argtypes)
-                break
+        # The `Val{LA}` flavours of `@artifact_str` dispatch require Julia 1.11+:
+        # older Julias don't accept a `Module` value as a type parameter, and
+        # `Artifacts._artifact_str`/`__artifact_str` were introduced in 1.11.
+        @static if VERSION >= v"1.11" &&
+                isdefined(Artifacts, :_artifact_str) && isdefined(Artifacts, :__artifact_str)
+            # `@artifact_str` passes `Val(LA)` where `LA` is the first of these
+            # modules imported by the JLL.  The `Val{Artifacts}` flavour is already
+            # covered by a `precompile(...)` statement in the Artifacts stdlib itself.
+            for modname in (:LazyArtifacts, :Pkg, :PkgArtifacts)
+                if isdefined(jll_module, modname)
+                    LA = getfield(jll_module, modname)
+                    argtypes = (Module, String, SubString{String}, String, Dict{String,Any},
+                                Base.SHA1, Base.BinaryPlatforms.Platform, Val{LA})
+                    Base.precompile(Artifacts._artifact_str, argtypes)
+                    Base.precompile(Artifacts.__artifact_str, argtypes)
+                    break
+                end
             end
         end
         Base.precompile(get_julia_libpaths, ())

--- a/src/wrapper_generators.jl
+++ b/src/wrapper_generators.jl
@@ -22,6 +22,7 @@ macro generate_wrapper_header(src_name)
             # to precompile these into Pkgimage
             Base.precompile(find_artifact_dir, ())
             Base.precompile(eager_mode, ())
+            JLLWrappers.precompile_init_callsites(@__MODULE__)
         end
     end)
 end


### PR DESCRIPTION
Avoids the load-time compilation seen with lazy artifacts, such as in LLVMExtra_jll.

Before:

```
julia> @time_imports using LLVMExtra_jll
[ Info: Precompiling LLVMExtra_jll [dad2f222-ce93-54a1-a47d-0025e8a3acab](cache misses: wrong source (3), incompatible header (3), mismatched flags (2))
Precompiling LLVMExtra_jll finished.
  2 dependencies successfully precompiled in 2 seconds. 28 already precompiled.
      0.9 ms  Printf
      8.5 ms  Dates
      0.8 ms  TOML
      0.6 ms  NetworkOptions
               ┌ 1.9 ms OpenSSL_jll.__init__()
      5.6 ms  OpenSSL_jll 52.83% compilation time
               ┌ 0.7 ms LibSSH2_jll.__init__()
      1.6 ms  LibSSH2_jll
               ┌ 0.9 ms LibGit2_jll.__init__()
      1.5 ms  LibGit2_jll
      4.7 ms  LibGit2
      3.9 ms  ArgTools
               ┌ 0.7 ms nghttp2_jll.__init__()
      1.4 ms  nghttp2_jll
               ┌ 1.2 ms Zlib_jll.__init__()
      1.9 ms  Zlib_jll
               ┌ 1.0 ms LibCURL_jll.__init__()
      1.7 ms  LibCURL_jll
               ┌ 0.0 ms MozillaCACerts_jll.__init__()
      0.7 ms  MozillaCACerts_jll
               ┌ 0.0 ms LibCURL.__init__()
      1.3 ms  LibCURL
               ┌ 3.2 ms Downloads.Curl.__init__()
      8.4 ms  Downloads
      1.4 ms  Tar
               ┌ 0.0 ms p7zip_jll.__init__()
      0.9 ms  p7zip_jll
      0.7 ms  UUIDs
      0.8 ms  Logging
               ┌ 0.0 ms Pkg.__init__()
     80.3 ms  Pkg
      1.0 ms  LazyArtifacts
      1.0 ms  Preferences
      1.0 ms  JLLWrappers
               ┌ 42.3 ms LLVMExtra_jll.__init__() 99.44% compilation time
    178.2 ms  LLVMExtra_jll 23.59% compilation time
```

After:

```
julia> @time_imports using LLVMExtra_jll
[ Info: Precompiling LLVMExtra_jll [dad2f222-ce93-54a1-a47d-0025e8a3acab](cache misses: wrong source (3), incompatible header (3), mismatched flags (2))
Precompiling LLVMExtra_jll finished.
  2 dependencies successfully precompiled in 2 seconds. 28 already precompiled.
      0.9 ms  Printf
      8.9 ms  Dates
      0.8 ms  TOML
      0.7 ms  NetworkOptions
               ┌ 1.9 ms OpenSSL_jll.__init__()
      5.3 ms  OpenSSL_jll 51.79% compilation time
               ┌ 0.6 ms LibSSH2_jll.__init__()
      1.3 ms  LibSSH2_jll
               ┌ 1.0 ms LibGit2_jll.__init__()
      1.6 ms  LibGit2_jll
      4.6 ms  LibGit2
      3.9 ms  ArgTools
               ┌ 0.6 ms nghttp2_jll.__init__()
      1.3 ms  nghttp2_jll
               ┌ 1.2 ms Zlib_jll.__init__()
      1.9 ms  Zlib_jll
               ┌ 1.0 ms LibCURL_jll.__init__()
      1.7 ms  LibCURL_jll
               ┌ 0.0 ms MozillaCACerts_jll.__init__()
      0.7 ms  MozillaCACerts_jll
               ┌ 0.0 ms LibCURL.__init__()
      1.2 ms  LibCURL
               ┌ 3.0 ms Downloads.Curl.__init__()
      7.9 ms  Downloads
      1.3 ms  Tar
               ┌ 0.0 ms p7zip_jll.__init__()
      0.8 ms  p7zip_jll
      0.7 ms  UUIDs
      0.7 ms  Logging
               ┌ 0.0 ms Pkg.__init__()
     81.3 ms  Pkg
      0.9 ms  LazyArtifacts
      1.0 ms  Preferences
      0.9 ms  JLLWrappers
               ┌ 0.2 ms LLVMExtra_jll.__init__()
    135.4 ms  LLVMExtra_jll
```

I don't particularly like the explicit nasty precompile statements, but AFAIU a precompilation workload was tried in the past and removed because it triggered actual compilation.